### PR TITLE
Add rudimentary support for adding downloads to a remote Aria2 server

### DIFF
--- a/Rule34.xxx Downloader/Forms/MainForm.cs
+++ b/Rule34.xxx Downloader/Forms/MainForm.cs
@@ -117,10 +117,13 @@ namespace R34Downloader.Forms
                     var countContent = R34ApiService.GetContentCount(request);
                     if (countContent > 0)
                     {
-                        if (folderBrowserDialog1.ShowDialog() != DialogResult.Cancel)
+                        if (SettingsModel.UseAria2 || folderBrowserDialog1.ShowDialog() != DialogResult.Cancel)
                         {
-                            Properties.Settings.Default.Path = folderBrowserDialog1.SelectedPath;
-                            Properties.Settings.Default.Save();
+                            if (!SettingsModel.UseAria2) // If not using aria2
+                            {
+                                Properties.Settings.Default.Path = folderBrowserDialog1.SelectedPath;
+                                Properties.Settings.Default.Save();
+                            }
 
                             var downloadingForm = new DownloadingForm((ushort)countContent);
                             downloadingForm.ShowDialog();
@@ -132,7 +135,7 @@ namespace R34Downloader.Forms
 
                                 var progress = new Progress<int>(s => toolStripProgressBar1.Value = s);
                                 var progress2 = new Progress<int>(s => toolStripStatusLabel2.Text = s + " / " + SettingsModel.Limit);
-                                await Task.Factory.StartNew(() => R34ApiService.DownloadContent(folderBrowserDialog1.SelectedPath, request, SettingsModel.Limit, progress, progress2), TaskCreationOptions.LongRunning);
+                                await Task.Factory.StartNew(() => R34ApiService.DownloadContent(folderBrowserDialog1.SelectedPath, request, SettingsModel.Limit, progress, progress2, SettingsModel.UseAria2), TaskCreationOptions.LongRunning);
 
                                 toolStripStatusLabel1.Text = "Download completed";
                                 if (MessageBox.Show("Download completed! Open the folder?", "Download completed", MessageBoxButtons.YesNo, MessageBoxIcon.Information) == DialogResult.Yes)

--- a/Rule34.xxx Downloader/Forms/SettingsForm.Designer.cs
+++ b/Rule34.xxx Downloader/Forms/SettingsForm.Designer.cs
@@ -33,7 +33,14 @@
             this.radioButton2 = new System.Windows.Forms.RadioButton();
             this.radioButton1 = new System.Windows.Forms.RadioButton();
             this.button1 = new System.Windows.Forms.Button();
+            this.groupBoxAria2 = new System.Windows.Forms.GroupBox();
+            this.checkBoxUseAria2 = new System.Windows.Forms.CheckBox();
+            this.textBoxAria2ServerUrl = new System.Windows.Forms.TextBox();
+            this.textBoxAria2SecretToken = new System.Windows.Forms.TextBox();
+            this.labelAria2ServerUrl = new System.Windows.Forms.Label();
+            this.labelAria2SecretToken = new System.Windows.Forms.Label();
             this.groupBox1.SuspendLayout();
+            this.groupBoxAria2.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBox1
@@ -74,7 +81,7 @@
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(169, 103);
+            this.button1.Location = new System.Drawing.Point(169, 250);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(75, 23);
             this.button1.TabIndex = 13;
@@ -82,12 +89,71 @@
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
+            // groupBoxAria2
+            // 
+            this.groupBoxAria2.Controls.Add(this.checkBoxUseAria2);
+            this.groupBoxAria2.Controls.Add(this.textBoxAria2ServerUrl);
+            this.groupBoxAria2.Controls.Add(this.textBoxAria2SecretToken);
+            this.groupBoxAria2.Controls.Add(this.labelAria2ServerUrl);
+            this.groupBoxAria2.Controls.Add(this.labelAria2SecretToken);
+            this.groupBoxAria2.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+            this.groupBoxAria2.Location = new System.Drawing.Point(12, 100);
+            this.groupBoxAria2.Name = "groupBoxAria2";
+            this.groupBoxAria2.Size = new System.Drawing.Size(360, 130);
+            this.groupBoxAria2.TabIndex = 19;
+            this.groupBoxAria2.TabStop = false;
+            this.groupBoxAria2.Text = " Aria2 Settings ";
+            // 
+            // checkBoxUseAria2
+            // 
+            this.checkBoxUseAria2.AutoSize = true;
+            this.checkBoxUseAria2.Location = new System.Drawing.Point(8, 21);
+            this.checkBoxUseAria2.Name = "checkBoxUseAria2";
+            this.checkBoxUseAria2.Size = new System.Drawing.Size(74, 20);
+            this.checkBoxUseAria2.TabIndex = 0;
+            this.checkBoxUseAria2.Text = "Use Aria2";
+            this.checkBoxUseAria2.UseVisualStyleBackColor = true;
+            this.checkBoxUseAria2.CheckedChanged += new System.EventHandler(this.checkBoxUseAria2_CheckedChanged);
+            // 
+            // textBoxAria2ServerUrl
+            // 
+            this.textBoxAria2ServerUrl.Location = new System.Drawing.Point(150, 50);
+            this.textBoxAria2ServerUrl.Name = "textBoxAria2ServerUrl";
+            this.textBoxAria2ServerUrl.Size = new System.Drawing.Size(200, 22);
+            this.textBoxAria2ServerUrl.TabIndex = 1;
+            // 
+            // textBoxAria2SecretToken
+            // 
+            this.textBoxAria2SecretToken.Location = new System.Drawing.Point(150, 80);
+            this.textBoxAria2SecretToken.Name = "textBoxAria2SecretToken";
+            this.textBoxAria2SecretToken.Size = new System.Drawing.Size(200, 22);
+            this.textBoxAria2SecretToken.TabIndex = 2;
+            // 
+            // labelAria2ServerUrl
+            // 
+            this.labelAria2ServerUrl.AutoSize = true;
+            this.labelAria2ServerUrl.Location = new System.Drawing.Point(8, 53);
+            this.labelAria2ServerUrl.Name = "labelAria2ServerUrl";
+            this.labelAria2ServerUrl.Size = new System.Drawing.Size(94, 16);
+            this.labelAria2ServerUrl.TabIndex = 3;
+            this.labelAria2ServerUrl.Text = "Aria2 Server URL:";
+            // 
+            // labelAria2SecretToken
+            // 
+            this.labelAria2SecretToken.AutoSize = true;
+            this.labelAria2SecretToken.Location = new System.Drawing.Point(8, 83);
+            this.labelAria2SecretToken.Name = "labelAria2SecretToken";
+            this.labelAria2SecretToken.Size = new System.Drawing.Size(94, 16);
+            this.labelAria2SecretToken.TabIndex = 4;
+            this.labelAria2SecretToken.Text = "Aria2 Secret Token:";
+            // 
             // SettingsForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(170)))), ((int)(((byte)(229)))), ((int)(((byte)(164)))));
-            this.ClientSize = new System.Drawing.Size(255, 137);
+            this.ClientSize = new System.Drawing.Size(400, 300);
+            this.Controls.Add(this.groupBoxAria2);
             this.Controls.Add(this.button1);
             this.Controls.Add(this.groupBox1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
@@ -99,6 +165,8 @@
             this.Load += new System.EventHandler(this.SettingsForm_Load);
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
+            this.groupBoxAria2.ResumeLayout(false);
+            this.groupBoxAria2.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -109,5 +177,11 @@
         private System.Windows.Forms.RadioButton radioButton2;
         private System.Windows.Forms.RadioButton radioButton1;
         private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.GroupBox groupBoxAria2;
+        private System.Windows.Forms.CheckBox checkBoxUseAria2;
+        private System.Windows.Forms.TextBox textBoxAria2ServerUrl;
+        private System.Windows.Forms.TextBox textBoxAria2SecretToken;
+        private System.Windows.Forms.Label labelAria2ServerUrl;
+        private System.Windows.Forms.Label labelAria2SecretToken;
     }
 }

--- a/Rule34.xxx Downloader/Forms/SettingsForm.cs
+++ b/Rule34.xxx Downloader/Forms/SettingsForm.cs
@@ -33,6 +33,12 @@ namespace R34Downloader.Forms
             {
                 radioButton2.Checked = true;
             }
+
+            textBoxAria2ServerUrl.Text = SettingsModel.Aria2ServerUrl;
+            textBoxAria2SecretToken.Text = SettingsModel.Aria2SecretToken;
+            checkBoxUseAria2.Checked = SettingsModel.UseAria2;
+
+            ToggleAria2Fields(SettingsModel.UseAria2);
         }
 
         private void radioButton_MouseClick(object sender, MouseEventArgs e)
@@ -40,9 +46,26 @@ namespace R34Downloader.Forms
             SettingsModel.IsApi = radioButton1.Checked;
         }
 
+        private void checkBoxUseAria2_CheckedChanged(object sender, EventArgs e)
+        {
+            SettingsModel.UseAria2 = checkBoxUseAria2.Checked;
+            ToggleAria2Fields(checkBoxUseAria2.Checked);
+        }
+
         private void button1_Click(object sender, EventArgs e)
         {
+            SettingsModel.Aria2ServerUrl = textBoxAria2ServerUrl.Text;
+            SettingsModel.Aria2SecretToken = textBoxAria2SecretToken.Text;
+            SettingsModel.UseAria2 = checkBoxUseAria2.Checked;
             Close();
+        }
+
+        private void ToggleAria2Fields(bool isVisible)
+        {
+            textBoxAria2ServerUrl.Visible = isVisible;
+            textBoxAria2SecretToken.Visible = isVisible;
+            labelAria2ServerUrl.Visible = isVisible;
+            labelAria2SecretToken.Visible = isVisible;
         }
 
         #endregion

--- a/Rule34.xxx Downloader/Models/SettingsModel.cs
+++ b/Rule34.xxx Downloader/Models/SettingsModel.cs
@@ -29,5 +29,20 @@
         /// Parsing method flag.
         /// </summary>
         public static bool IsApi { get; set; }
+
+        /// <summary>
+        /// Aria2 server URL.
+        /// </summary>
+        public static string Aria2ServerUrl { get; set; }
+
+        /// <summary>
+        /// Aria2 secret token for authentication.
+        /// </summary>
+        public static string Aria2SecretToken { get; set; }
+
+        /// <summary>
+        /// Flag for enabling or disabling aria2.
+        /// </summary>
+        public static bool UseAria2 { get; set; }
     }
 }

--- a/Rule34.xxx Downloader/R34Downloader.csproj
+++ b/Rule34.xxx Downloader/R34Downloader.csproj
@@ -58,6 +58,9 @@
     <Reference Include="HtmlAgilityPack, Version=1.11.46.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <HintPath>..\packages\HtmlAgilityPack.1.11.46\lib\Net45\HtmlAgilityPack.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/Rule34.xxx Downloader/packages.config
+++ b/Rule34.xxx Downloader/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="HtmlAgilityPack" version="1.11.46" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net481" />
 </packages>


### PR DESCRIPTION
This PR hopes to add a basic framework which allows for adding downloads to a Aria2 server. This is done via JSON-RPC. This is in response to #18 

Pros:
- Aria2 might be more efficient and quicker to download multiple files
- The downloads are saved on the server and therefore do not take space on you local machine

Cons:
- Setting the download directory on a remote server is non-trivial (currently this code doesn't set it so the downloads are placed in Aria2's default download directory)
- SecretTokens/URL endpoints are not saved securely.